### PR TITLE
fix: update keyboard visibility logic based on name length (greater t…

### DIFF
--- a/src/components/KeyboardSignature.tsx
+++ b/src/components/KeyboardSignature.tsx
@@ -60,7 +60,7 @@ export const KeyboardSignature = () => {
 
   // Flash keyboard when name changes
   useEffect(() => {
-    if (name.length > 0) {
+    if (name.length > 1) {
       setKeyboardVisible(true);
 
       const timer = setTimeout(() => {
@@ -217,7 +217,7 @@ export const KeyboardSignature = () => {
         {/* Keyboard */}
         <div
           className={`relative transition-opacity ease-out ${
-            name.length === 0
+            name.length < 2
               ? "opacity-100"
               : keyboardVisible
                 ? "opacity-100 brightness-125 duration-50"
@@ -294,7 +294,7 @@ export const KeyboardSignature = () => {
       </div>
 
       <div
-        className={`max-sm:w-[20rem] max-sm:mx-auto flex flex-col gap-2 sm:mt-8 transition-all ease-in-out ${name.length > 0 ? "opacity-100 translate-y-0 duration-1000" : "pointer-events-none opacity-0 translate-y-2 duration-150"}`}
+        className={`max-sm:w-[20rem] max-sm:mx-auto flex flex-col gap-2 sm:mt-8 transition-all ease-in-out ${name.length > 1 ? "opacity-100 translate-y-0 duration-1000" : "pointer-events-none opacity-0 translate-y-2 duration-150"}`}
       >
         <div className="grid grid-cols-2 gap-2">
           <button


### PR DESCRIPTION
This pull request updates the logic for showing and hiding UI elements in the `KeyboardSignature` component, making the behavior more consistent by requiring the user's name to be at least two characters long before certain elements become visible. The main changes are adjustments to the conditions that control the visibility and transitions of the keyboard and related UI.

**UI behavior improvements:**

* The keyboard now only flashes when the `name` has more than one character, instead of any non-empty value.
* The keyboard's opacity and transition classes are now determined by whether the `name` has fewer than two characters, instead of being empty.
* The visibility and transition of the container below the keyboard are now based on the `name` being longer than one character, improving consistency in UI transitions.